### PR TITLE
[LoLi-Bot] 同步 ANiMe: 更新 《Fate/Grand Order -绝对魔兽战线巴比伦尼亚-》《靠死亡游戏混饭吃。》

### DIFF
--- a/data/animeCdnVersion.ts
+++ b/data/animeCdnVersion.ts
@@ -1,3 +1,3 @@
 // 由 HXLoLi-ANiMe 仓库 GitHub Actions 自动发 PR 更新
 // Tag 格式: HX-{随机6位}-{时间戳}
-export const ANIME_CDN_TAG = 'HX-20260407081709-tr93wf';
+export const ANIME_CDN_TAG = 'HX-20260408081620-CzbFmr';


### PR DESCRIPTION
## 📺 HXLoLi-ANiMe 数据同步

更新 `ANIME_CDN_TAG` → `HX-20260408081620-CzbFmr`

### 🔄 更新番剧
- 《Fate/Grand Order -绝对魔兽战线巴比伦尼亚-》
- 《靠死亡游戏混饭吃。》

### 📊 统计
| 项目 | 数量 |
|------|------|
| 新增番剧 | 0 |
| 更新信息 | 2 |
| 新增图片 | 37 |

---
*由 HXLoLi-ANiMe CI 自动生成*