### PR TITLE
[LoLi-Bot] 同步 ANiMe: 新增 《别当欧尼酱了！》, 更新 《Fate/Grand Order -绝对魔兽战线巴比伦尼亚-》《关于我转生变成史莱姆这档事 第四季》

### DIFF
--- a/data/animeCdnVersion.ts
+++ b/data/animeCdnVersion.ts
@@ -1,3 +1,3 @@
 // 由 HXLoLi-ANiMe 仓库 GitHub Actions 自动发 PR 更新
 // Tag 格式: HX-{随机6位}-{时间戳}
-export const ANIME_CDN_TAG = 'HX-20260410082353-k9K42b';
+export const ANIME_CDN_TAG = 'HX-20260414084737-WVPeop';


### PR DESCRIPTION
## 📺 HXLoLi-ANiMe 数据同步

更新 `ANIME_CDN_TAG` → `HX-20260414084737-WVPeop`

### 🆕 新增番剧
- **《别当欧尼酱了！》** (お兄ちゃんはおしまい！) ⭐7.6 | 📅2023-01-05
### 🔄 更新番剧
- 《Fate/Grand Order -绝对魔兽战线巴比伦尼亚-》
- 《关于我转生变成史莱姆这档事 第四季》

### 📊 统计
| 项目 | 数量 |
|------|------|
| 新增番剧 | 1 |
| 更新信息 | 2 |
| 新增图片 | 62 |

---
*由 HXLoLi-ANiMe CI 自动生成*