### PR TITLE
[LoLi-Bot] 同步 ANiMe: 更新 《关于我转生变成史莱姆这档事 第四季》

### DIFF
--- a/data/animeCdnVersion.ts
+++ b/data/animeCdnVersion.ts
@@ -1,3 +1,3 @@
 // 由 HXLoLi-ANiMe 仓库 GitHub Actions 自动发 PR 更新
 // Tag 格式: HX-{随机6位}-{时间戳}
-export const ANIME_CDN_TAG = 'HX-20260417084825-7IGl8N';
+export const ANIME_CDN_TAG = 'HX-20260418164836-dWiAcm';


### PR DESCRIPTION
## 📺 HXLoLi-ANiMe 数据同步

更新 `ANIME_CDN_TAG` → `HX-20260418164836-dWiAcm`

### 🔄 更新番剧
- 《关于我转生变成史莱姆这档事 第四季》

### 📊 统计
| 项目 | 数量 |
|------|------|
| 新增番剧 | 0 |
| 更新信息 | 1 |
| 新增图片 | 0 |

---
*由 HXLoLi-ANiMe CI 自动生成*