### PR TITLE
[LoLi-Bot] 同步 Music: 「[feat] 新增 モノクローム果樹園 (黑白果树园) - 大野柚布子、遠藤ゆりか 歌曲歌词」

### DIFF
--- a/data/musicCdnVersion.ts
+++ b/data/musicCdnVersion.ts
@@ -1,3 +1,3 @@
 // 由 HXLoLi-Music 仓库 GitHub Actions 自动发 PR 更新
 // Tag 格式: HX-{随机6位}-{时间戳}
-export const MUSIC_CDN_TAG = 'HX-20260404142114-ClSFkE';
+export const MUSIC_CDN_TAG = 'HX-20260426165906-Qsl3CK';


### PR DESCRIPTION
## 🎵 HXLoLi-Music 数据同步

更新 `MUSIC_CDN_TAG` → `HX-20260426165906-Qsl3CK`

来源: `[feat] 新增 モノクローム果樹園 (黑白果树园) - 大野柚布子、遠藤ゆりか 歌曲歌词`

---
*由 HXLoLi-Music CI 自动生成*