### PR TITLE
[LoLi-Bot] 同步 ANiMe: 新增 《女神“异世界转生想成为什么”我“勇者的肋骨”》, 更新 《关于我转生变成史莱姆这档事 第四季》

### DIFF
--- a/data/animeCdnVersion.ts
+++ b/data/animeCdnVersion.ts
@@ -1,3 +1,3 @@
 // 由 HXLoLi-ANiMe 仓库 GitHub Actions 自动发 PR 更新
 // Tag 格式: HX-{随机6位}-{时间戳}
-export const ANIME_CDN_TAG = 'HX-20260425165042-H7AV9v';
+export const ANIME_CDN_TAG = 'HX-20260427092527-ajT1GB';


### PR DESCRIPTION
## 📺 HXLoLi-ANiMe 数据同步

更新 `ANIME_CDN_TAG` → `HX-20260427092527-ajT1GB`

### 🆕 新增番剧
- **《女神“异世界转生想成为什么”我“勇者的肋骨”》** (女神『異世界転生何になりたいですか』俺「勇者の肋骨で」) ⭐7 | 📅2026-04-07
### 🔄 更新番剧
- 《关于我转生变成史莱姆这档事 第四季》

### 📊 统计
| 项目 | 数量 |
|------|------|
| 新增番剧 | 1 |
| 更新信息 | 1 |
| 新增图片 | 10 |

---
*由 HXLoLi-ANiMe CI 自动生成*