### PR TITLE
[LoLi-Bot] 同步 Music: 「[fix] 修复裁剪问题(如果出现在中间会无法正确裁剪、导致双行重叠) (目前仅初步修复)」

### DIFF
--- a/data/musicCdnVersion.ts
+++ b/data/musicCdnVersion.ts
@@ -1,3 +1,3 @@
 // 由 HXLoLi-Music 仓库 GitHub Actions 自动发 PR 更新
 // Tag 格式: HX-{随机6位}-{时间戳}
-export const MUSIC_CDN_TAG = 'HX-20260426165906-Qsl3CK';
+export const MUSIC_CDN_TAG = 'HX-20260428154109-5cxe6A';


### PR DESCRIPTION
## 🎵 HXLoLi-Music 数据同步

更新 `MUSIC_CDN_TAG` → `HX-20260428154109-5cxe6A`

来源: `[fix] 修复裁剪问题(如果出现在中间会无法正确裁剪、导致双行重叠) (目前仅初步修复)`

---
*由 HXLoLi-Music CI 自动生成*