### PR TITLE
[LoLi-Bot] 同步 ANiMe: 新增 《天使的3P!》

### DIFF
--- a/data/animeCdnVersion.ts
+++ b/data/animeCdnVersion.ts
@@ -1,3 +1,3 @@
 // 由 HXLoLi-ANiMe 仓库 GitHub Actions 自动发 PR 更新
 // Tag 格式: HX-{随机6位}-{时间戳}
-export const ANIME_CDN_TAG = 'HX-20260427092527-ajT1GB';
+export const ANIME_CDN_TAG = 'HX-20260428174927-XvEMTc';


### PR DESCRIPTION
## 📺 HXLoLi-ANiMe 数据同步

更新 `ANIME_CDN_TAG` → `HX-20260428174927-XvEMTc`

### 🆕 新增番剧
- **《天使的3P!》** (天使の3P!) ⭐6.1 | 📅2017-07-10

### 📊 统计
| 项目 | 数量 |
|------|------|
| 新增番剧 | 1 |
| 更新信息 | 0 |
| 新增图片 | 19 |

---
*由 HXLoLi-ANiMe CI 自动生成*