### PR TITLE
[LoLi-Bot] 同步 ANiMe: 更新 《欢迎来到实力至上主义教室 第四季》《Re：从零开始的异世界生活 第四季 丧失篇》

### DIFF
--- a/data/animeCdnVersion.ts
+++ b/data/animeCdnVersion.ts
@@ -1,3 +1,3 @@
 // 由 HXLoLi-ANiMe 仓库 GitHub Actions 自动发 PR 更新
 // Tag 格式: HX-{随机6位}-{时间戳}
-export const ANIME_CDN_TAG = 'HX-20260610105952-xtJhZ0';
+export const ANIME_CDN_TAG = 'HX-20260611112544-1CE21D';


### PR DESCRIPTION
## 📺 HXLoLi-ANiMe 数据同步

更新 `ANIME_CDN_TAG` → `HX-20260611112544-1CE21D`

### 🔄 更新番剧
- 《欢迎来到实力至上主义教室 第四季》
- 《Re：从零开始的异世界生活 第四季 丧失篇》

### 📊 统计
| 项目 | 数量 |
|------|------|
| 新增番剧 | 0 |
| 更新信息 | 2 |
| 新增图片 | 6 |

---
*由 HXLoLi-ANiMe CI 自动生成*