### PR TITLE
[LoLi-Bot] 同步 ANiMe: 更新 《无职转生 第三季 ～到了异世界就拿出真本事～》《欢迎来到实力至上主义教室 第四季》《关于我转生变成史莱姆这档事 第四季》 等 4 部番剧信息

### DIFF
--- a/data/animeCdnVersion.ts
+++ b/data/animeCdnVersion.ts
@@ -1,3 +1,3 @@
 // 由 HXLoLi-ANiMe 仓库 GitHub Actions 自动发 PR 更新
 // Tag 格式: HX-{随机6位}-{时间戳}
-export const ANIME_CDN_TAG = 'HX-20260622125418-PXMdis';
+export const ANIME_CDN_TAG = 'HX-20260630103429-99cbMU';


### PR DESCRIPTION
## 📺 HXLoLi-ANiMe 数据同步

更新 `ANIME_CDN_TAG` → `HX-20260630103429-99cbMU`

### 🔄 更新番剧
- 《无职转生 第三季 ～到了异世界就拿出真本事～》
- 《欢迎来到实力至上主义教室 第四季》
- 《关于我转生变成史莱姆这档事 第四季》
- 《女神“异世界转生想成为什么”我“勇者的肋骨”》

### 📊 统计
| 项目 | 数量 |
|------|------|
| 新增番剧 | 0 |
| 更新信息 | 4 |
| 新增图片 | 9 |

---
*由 HXLoLi-ANiMe CI 自动生成*