### PR TITLE
[LoLi-Bot] 同步 ANiMe: 新增 《与你相恋到生命尽头》《碧蓝之海 第三季》, 更新 《无职转生 第三季 ～到了异世界就拿出真本事～》《关于我转生变成史莱姆这档事 第四季》

### DIFF
--- a/data/animeCdnVersion.ts
+++ b/data/animeCdnVersion.ts
@@ -1,3 +1,3 @@
 // 由 HXLoLi-ANiMe 仓库 GitHub Actions 自动发 PR 更新
 // Tag 格式: HX-{随机6位}-{时间戳}
-export const ANIME_CDN_TAG = 'HX-20260630103429-99cbMU';
+export const ANIME_CDN_TAG = 'HX-20260717091344-Q395VX';


### PR DESCRIPTION
## 📺 HXLoLi-ANiMe 数据同步

更新 `ANIME_CDN_TAG` → `HX-20260717091344-Q395VX`

### 🆕 新增番剧
- **《与你相恋到生命尽头》** (きみが死ぬまで恋をしたい) ⭐7.2 | 📅2026-07-07
- **《碧蓝之海 第三季》** (ぐらんぶる Season 3) ⭐7.2 | 📅2026-07-06
### 🔄 更新番剧
- 《无职转生 第三季 ～到了异世界就拿出真本事～》
- 《关于我转生变成史莱姆这档事 第四季》

### 📊 统计
| 项目 | 数量 |
|------|------|
| 新增番剧 | 2 |
| 更新信息 | 2 |
| 新增图片 | 46 |

---
*由 HXLoLi-ANiMe CI 自动生成*