### PR TITLE
[LoLi-Bot] 同步 ANiMe: 新增 《幼女战记 第二季》, 更新 《无职转生 第三季 ～到了异世界就拿出真本事～》《关于我转生变成史莱姆这档事 第四季》《与你相恋到生命尽头》 等 4 部番剧信息

### DIFF
--- a/data/animeCdnVersion.ts
+++ b/data/animeCdnVersion.ts
@@ -1,3 +1,3 @@
 // 由 HXLoLi-ANiMe 仓库 GitHub Actions 自动发 PR 更新
 // Tag 格式: HX-{随机6位}-{时间戳}
-export const ANIME_CDN_TAG = 'HX-20260717091344-Q395VX';
+export const ANIME_CDN_TAG = 'HX-20260801091118-9UM2cW';


### PR DESCRIPTION
## 📺 HXLoLi-ANiMe 数据同步

更新 `ANIME_CDN_TAG` → `HX-20260801091118-9UM2cW`

### 🆕 新增番剧
- **《幼女战记 第二季》** (幼女戦記Ⅱ) ⭐7.2 | 📅2026-07-08
### 🔄 更新番剧
- 《无职转生 第三季 ～到了异世界就拿出真本事～》
- 《关于我转生变成史莱姆这档事 第四季》
- 《与你相恋到生命尽头》
- 《碧蓝之海 第三季》

### 📊 统计
| 项目 | 数量 |
|------|------|
| 新增番剧 | 1 |
| 更新信息 | 4 |
| 新增图片 | 40 |

---
*由 HXLoLi-ANiMe CI 自动生成*