### PR TITLE
[LoLi-Bot] 同步 ANiMe: 更新 《少女波子汽水》《无职转生 第三季 ～到了异世界就拿出真本事～》《碧蓝之海 第三季》

### DIFF
--- a/data/animeCdnVersion.ts
+++ b/data/animeCdnVersion.ts
@@ -1,3 +1,3 @@
 // 由 HXLoLi-ANiMe 仓库 GitHub Actions 自动发 PR 更新
 // Tag 格式: HX-{随机6位}-{时间戳}
-export const ANIME_CDN_TAG = 'HX-20260802091317-brPCAh';
+export const ANIME_CDN_TAG = 'HX-20260805174402-zkiX0U';


### PR DESCRIPTION
## 📺 HXLoLi-ANiMe 数据同步

更新 `ANIME_CDN_TAG` → `HX-20260805174402-zkiX0U`

### 🔄 更新番剧
- 《少女波子汽水》
- 《无职转生 第三季 ～到了异世界就拿出真本事～》
- 《碧蓝之海 第三季》

### 📊 统计
| 项目 | 数量 |
|------|------|
| 新增番剧 | 0 |
| 更新信息 | 3 |
| 新增图片 | 9 |

---
*由 HXLoLi-ANiMe CI 自动生成*