### PR TITLE
[LoLi-Bot] 同步 ANiMe: 新增 《咔嗒咔嗒》《咔嗒咔嗒 第二季》

### DIFF
--- a/data/animeCdnVersion.ts
+++ b/data/animeCdnVersion.ts
@@ -1,3 +1,3 @@
 // 由 HXLoLi-ANiMe 仓库 GitHub Actions 自动发 PR 更新
 // Tag 格式: HX-{随机6位}-{时间戳}
-export const ANIME_CDN_TAG = 'HX-20260805174402-zkiX0U';
+export const ANIME_CDN_TAG = 'HX-20260808163712-v2Dv8K';


### PR DESCRIPTION
## 📺 HXLoLi-ANiMe 数据同步

更新 `ANIME_CDN_TAG` → `HX-20260808163712-v2Dv8K`

### 🆕 新增番剧
- **《咔嗒咔嗒》** (ガチアクタ) ⭐6.2 | 📅2025-07-06
- **《咔嗒咔嗒 第二季》** (ガチアクタ 第2期) ⭐10 | 📅null

### 📊 统计
| 项目 | 数量 |
|------|------|
| 新增番剧 | 2 |
| 更新信息 | 0 |
| 新增图片 | 57 |

---
*由 HXLoLi-ANiMe CI 自动生成*