### PR TITLE
[LoLi-Bot] 同步 ANiMe: 更新 《幼女战记 第二季》《无职转生 第三季 ～到了异世界就拿出真本事～》

### DIFF
--- a/data/animeCdnVersion.ts
+++ b/data/animeCdnVersion.ts
@@ -1,3 +1,3 @@
 // 由 HXLoLi-ANiMe 仓库 GitHub Actions 自动发 PR 更新
 // Tag 格式: HX-{随机6位}-{时间戳}
-export const ANIME_CDN_TAG = 'HX-20260808163712-v2Dv8K';
+export const ANIME_CDN_TAG = 'HX-20260809075618-APLuCn';


### PR DESCRIPTION
## 📺 HXLoLi-ANiMe 数据同步

更新 `ANIME_CDN_TAG` → `HX-20260809075618-APLuCn`

### 🔄 更新番剧
- 《幼女战记 第二季》
- 《无职转生 第三季 ～到了异世界就拿出真本事～》

### 📊 统计
| 项目 | 数量 |
|------|------|
| 新增番剧 | 0 |
| 更新信息 | 2 |
| 新增图片 | 1 |

---
*由 HXLoLi-ANiMe CI 自动生成*