### PR TITLE
[LoLi-Bot] 同步 ANiMe: 新增 《Re：从零开始的异世界生活 第四季 夺还篇》, 更新 《幼女战记 第二季》《无职转生 第三季 ～到了异世界就拿出真本事～》《关于我转生变成史莱姆这档事 第四季》 等 4 部番剧信息

### DIFF
--- a/data/animeCdnVersion.ts
+++ b/data/animeCdnVersion.ts
@@ -1,3 +1,3 @@
 // 由 HXLoLi-ANiMe 仓库 GitHub Actions 自动发 PR 更新
 // Tag 格式: HX-{随机6位}-{时间戳}
-export const ANIME_CDN_TAG = 'HX-20260823073830-4ijsai';
+export const ANIME_CDN_TAG = 'HX-20260906113630-E1EgjV';


### PR DESCRIPTION
## 📺 HXLoLi-ANiMe 数据同步

更新 `ANIME_CDN_TAG` → `HX-20260906113630-E1EgjV`

### 🆕 新增番剧
- **《Re：从零开始的异世界生活 第四季 夺还篇》** (Re:ゼロから始める異世界生活 4th season 奪還編) ⭐7.9 | 📅2026-08-12
### 🔄 更新番剧
- 《幼女战记 第二季》
- 《无职转生 第三季 ～到了异世界就拿出真本事～》
- 《关于我转生变成史莱姆这档事 第四季》
- 《碧蓝之海 第三季》

### 📊 统计
| 项目 | 数量 |
|------|------|
| 新增番剧 | 1 |
| 更新信息 | 4 |
| 新增图片 | 12 |

---
*由 HXLoLi-ANiMe CI 自动生成*